### PR TITLE
Update CI to test on Node 22 instead of Node 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [18, 20, 22]
       fail-fast: false
     
     steps:


### PR DESCRIPTION
## Summary

- Updates CI matrix to test on Node 22 instead of Node 21
- Node 22 is now the current LTS release

## Test plan

- [x] CI passes on Node 18, 20, and 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)